### PR TITLE
Remove `bottle :unneeded`

### DIFF
--- a/Formula/catalytic-cli.rb
+++ b/Formula/catalytic-cli.rb
@@ -2,7 +2,6 @@ class CatalyticCli < Formula
   desc "Catalytic CLI"
   homepage "https://catalytic-developer.readme.io/reference/cli"
   version "1.0.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/catalyticlabs/homebrew-catalytic/releases/download/v1.0.0-cli/catalytic_1.0.0_osx-x64.tar.gz"


### PR DESCRIPTION
It generates the following warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the catalyticlabs/catalytic tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/catalyticlabs/homebrew-catalytic/Formula/catalytic-cli.rb:5
```

See https://stackoverflow.com/a/45163490
See https://github.com/Homebrew/brew/pull/11239